### PR TITLE
add VarChangeDeprecationFix

### DIFF
--- a/fixes/VarChangeDeprecationFix.lua
+++ b/fixes/VarChangeDeprecationFix.lua
@@ -1,0 +1,38 @@
+require "Apollo"
+_G.CarbineUIFixes = rawget(_G, "CarbineUIFixes") or {}
+
+local VarChangeDeprecationFix = {
+  url = "https://forums.wildstar-online.com/forums/index.php?/topic/153645-ptr-pt2-breaks-a-lot-of-addons-api-changes-or-did-smth-break/",
+  description = {
+    "Carbine quietly deprecated the VarChange_FrameCount event which was used as a next frame event for many older addons.",
+  }
+}
+
+function VarChangeDeprecationFix:new(o)
+  o = o or {}
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+function VarChangeDeprecationFix:Init()
+  self:UnloadVarChangeDeprecationFix()
+end
+
+function VarChangeDeprecationFix:UnloadVarChangeDeprecationFix()
+  local wf = Apollo.GetAddon("VarChangeDeprecationFix")
+  if wf then
+    wf.OnLoad = function () end
+  end
+end
+
+function VarChangeDeprecationFix:OnLoad()
+  self:UnloadVarChangeDeprecationFix()
+  Apollo.RegisterEventHandler("NextFrame", "OnNextFrame", self)
+end
+
+function VarChangeDeprecationFix:OnNextFrame()
+  Event_FireGenericEvent("VarChange_FrameCount")
+end
+
+_G.CarbineUIFixes.VarChangeDeprecationFix = VarChangeDeprecationFix:new()

--- a/toc.xml
+++ b/toc.xml
@@ -14,7 +14,7 @@
   <Script Name="fixes\ActiveChatTabFix.lua"/>
   <Script Name="fixes\QueuePopDisappearFix.lua"/>
   <Script Name="fixes\GlobalNonCombatSpellbookFix.lua"/>
-
+  <Script Name="fixes\VarChangeDeprecationFix.lua"/>
 
   <!-- Core functionality -->
   <Script Name="CarbineUIFixes.lua"/>


### PR DESCRIPTION
aliases the NextFrame event to the deprecated VarChange_FrameCount event
